### PR TITLE
fix: Fix axProvider to use llm.ts

### DIFF
--- a/llm-as-a-judge-mvp/lib/infrastructure/ax/AxProvider.ts
+++ b/llm-as-a-judge-mvp/lib/infrastructure/ax/AxProvider.ts
@@ -6,8 +6,6 @@ import { JUDGE_MODEL, MODEL_TIMEOUT_MS, TARGET_MODEL } from "@/lib/config/llm";
 import { JudgeResult, LLMProvider } from "@/lib/domain/llm";
 import type { AxMethodId } from "@/lib/contracts/generateEvaluate";
 
-const TARGET_AX_MODEL = AxAIGoogleGeminiModel.Gemini25Flash;
-const JUDGE_AX_MODEL = AxAIGoogleGeminiModel.Gemini25Pro;
 
 type AxProviderConfig = {
   axMethod?: AxMethodId;
@@ -44,7 +42,7 @@ export class AxProvider implements LLMProvider {
       name: "google-gemini",
       apiKey: this.getApiKey(),
       config: {
-        model: TARGET_AX_MODEL,
+        model: TARGET_MODEL as AxAIGoogleGeminiModel,
         temperature: 0.7
       },
     });
@@ -55,7 +53,7 @@ export class AxProvider implements LLMProvider {
       name: "google-gemini",
       apiKey: this.getApiKey(),
       config: {
-        model: JUDGE_AX_MODEL,
+        model: JUDGE_MODEL as AxAIGoogleGeminiModel,
         temperature: 0
       }
     });
@@ -220,6 +218,7 @@ export class AxProvider implements LLMProvider {
           "Model call timed out."
         );
       }
+      console.error("[AxProvider.judgeOutput] unexpected error:", error);
       throw new AppError(
         502,
         "PROVIDER_ERROR",


### PR DESCRIPTION
## 背景

デフォルトで利用される AxProviderは llm.tsで設定しているモデルの設定を参照しないため、llm.tsでモデルの指定を変更しているケースで、画面表示と実際にaxが使うモデルがずれることがある。(gemini 無料枠では gemini-2.5-proのクオータが0なので、利用できない)

## 修正内容

- llm.tsで指定した値を利用するようにしました
- 握りつぶしていたエラーの詳細を鯖ログとして出すようにしました
