### PR TITLE
perf: Optimize PromptDiffView and reduce EvaluateTab polling frequency

### DIFF
--- a/llm-as-a-judge-mvp/app/components/PromptDiffView.tsx
+++ b/llm-as-a-judge-mvp/app/components/PromptDiffView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { CSSProperties } from "react";
+import { memo, useMemo, type CSSProperties } from "react";
 import { diffLines } from "diff";
 
 /**
@@ -16,30 +16,32 @@ type Props = {
   initialHeight?: number;
 };
 
-export function PromptDiffView({
+type Row = { left: string; right: string; leftStyle: "removed" | "unchanged" | "empty"; rightStyle: "added" | "unchanged" | "empty" };
+
+export const PromptDiffView = memo(function PromptDiffView({
   before,
   after,
   beforeLabel = "現在のプロンプト",
   afterLabel = "改善案",
   initialHeight = 320
 }: Props) {
-  const diff = diffLines(before, after);
-
-  type Row = { left: string; right: string; leftStyle: "removed" | "unchanged" | "empty"; rightStyle: "added" | "unchanged" | "empty" };
-  const rows: Row[] = [];
-
-  for (const part of diff) {
-    const lines = (part.value || "").split("\n").filter((l, i, arr) => i < arr.length - 1 || l !== "");
-    for (const line of lines) {
-      if (part.removed) {
-        rows.push({ left: line, right: "", leftStyle: "removed", rightStyle: "empty" });
-      } else if (part.added) {
-        rows.push({ left: "", right: line, leftStyle: "empty", rightStyle: "added" });
-      } else {
-        rows.push({ left: line, right: line, leftStyle: "unchanged", rightStyle: "unchanged" });
+  const rows = useMemo<Row[]>(() => {
+    const diff = diffLines(before, after);
+    const result: Row[] = [];
+    for (const part of diff) {
+      const lines = (part.value || "").split("\n").filter((l, i, arr) => i < arr.length - 1 || l !== "");
+      for (const line of lines) {
+        if (part.removed) {
+          result.push({ left: line, right: "", leftStyle: "removed", rightStyle: "empty" });
+        } else if (part.added) {
+          result.push({ left: "", right: line, leftStyle: "empty", rightStyle: "added" });
+        } else {
+          result.push({ left: line, right: line, leftStyle: "unchanged", rightStyle: "unchanged" });
+        }
       }
     }
-  }
+    return result;
+  }, [before, after]);
 
   const cellStyle = (style: Row["leftStyle"] | Row["rightStyle"]) => {
     if (style === "removed")
@@ -78,7 +80,7 @@ export function PromptDiffView({
               }}
             >
               {rows.map((r, i) => (
-                <span key={i} style={{ display: "block", padding: "0 4px", ...cellStyle(r.leftStyle) }}>
+                <span key={`left-${i}`} style={{ display: "block", padding: "0 4px", ...cellStyle(r.leftStyle) }}>
                   {r.leftStyle === "removed" ? "- " : r.leftStyle === "unchanged" ? "  " : ""}
                   {r.left || "\u00A0"}
                 </span>
@@ -103,7 +105,7 @@ export function PromptDiffView({
               }}
             >
               {rows.map((r, i) => (
-                <span key={i} style={{ display: "block", padding: "0 4px", ...cellStyle(r.rightStyle) }}>
+                <span key={`right-${i}`} style={{ display: "block", padding: "0 4px", ...cellStyle(r.rightStyle) }}>
                   {r.rightStyle === "added" ? "+ " : r.rightStyle === "unchanged" ? "  " : ""}
                   {r.right || "\u00A0"}
                 </span>
@@ -114,4 +116,4 @@ export function PromptDiffView({
       </div>
     </div>
   );
-}
+});

--- a/llm-as-a-judge-mvp/app/components/tabs/EvaluateTabContent.tsx
+++ b/llm-as-a-judge-mvp/app/components/tabs/EvaluateTabContent.tsx
@@ -130,7 +130,7 @@ export function EvaluateTabContent({
   useEffect(() => {
     if (!loading) return;
     const startAt = Date.now();
-    const intervalId = setInterval(() => setElapsedMs(Date.now() - startAt), 200);
+    const intervalId = setInterval(() => setElapsedMs(Date.now() - startAt), 1000);
     return () => clearInterval(intervalId);
   }, [loading]);
 


### PR DESCRIPTION
## 背景
- 生成・ Judgeプロンプト改善中にFEがCPUリソースを大量に使っていて、ご老体のPCにとってきつい状態になっている

## 原因

- setIntervalの間隔がページによっては短い
- 画面時間の経過時間が参照している値が更新されるたびに、diffの再計算（重たい処理）が走っていた

## 変更内容
- setIntervalの間隔を200 ms -> 1000 msに変更しました
  - 画面に表示される経過時間の正確性は劣化しますが、人間が気にするほどの影響はない
- 差分表示のための計算がメモ化されず、レンダリングのたびに再計算されていたので、メモ化しました

## Details

- Wrap PromptDiffView with React.memo to prevent unnecessary re-renders
- Memoize row calculation with useMemo to avoid recomputing diff on every render
- Reduce elapsed time polling interval from 200ms to 1000ms in EvaluateTabContent
- Move Row type definition to module level for clarity